### PR TITLE
Added quality to dishes, and to mill products

### DIFF
--- a/CookingSkillRedux/Core/CookingApi.cs
+++ b/CookingSkillRedux/Core/CookingApi.cs
@@ -18,7 +18,7 @@ namespace CookingSkill.Core
         /// <param name="recipe">The crafting recipe.</param>
         /// <param name="item">The crafted item from the recipe. Nothing is changed if the recipe isn't cooking.</param>
         /// <returns>Returns the held item.</returns>
-        Item PreCook(CraftingRecipe recipe, Item item, Dictionary<Item, int> consumed_items, Farmer who);
+        Item PreCook(CraftingRecipe recipe, Item item, bool betterCrafting = false);
 
         /// <summary>
         /// Grants the player EXP and increases the held Item by the value of the crafting recipe.
@@ -27,19 +27,19 @@ namespace CookingSkill.Core
         /// <param name="heldItem">The held item, to increase the stack size of and to get the edibility of.</param>
         /// <param name="who"> the player who did the cooking, to grant exp to.</param>
         /// <returns>Returns the held item.</returns>
-        Item PostCook(CraftingRecipe recipe, Item heldItem, Farmer who);
+        Item PostCook(CraftingRecipe recipe, Item heldItem, Dictionary<Item, int> consumed_items, Farmer who, bool betterCrafting = false);
     }
 
     public class CookingAPI : ICookingApi
     {
-        public Item PreCook(CraftingRecipe recipe, Item item, Dictionary<Item, int> consumed_items, Farmer who)
+        public Item PreCook(CraftingRecipe recipe, Item item, bool betterCrafting = false)
         {
-            return CookingSkill.Core.Events.PreCook(recipe, item, consumed_items, who);
+            return CookingSkill.Core.Events.PreCook(recipe, item, betterCrafting);
         }
 
-        public Item PostCook(CraftingRecipe recipe, Item heldItem, Farmer who)
+        public Item PostCook(CraftingRecipe recipe, Item heldItem, Dictionary<Item,int> consumedItems, Farmer who, bool betterCrafting = false)
         {
-            return CookingSkill.Core.Events.PostCook(recipe, heldItem, who);
+            return CookingSkill.Core.Events.PostCook(recipe, heldItem, consumedItems, who, betterCrafting);
         }
     }
 }

--- a/CookingSkillRedux/Core/CookingApi.cs
+++ b/CookingSkillRedux/Core/CookingApi.cs
@@ -18,7 +18,7 @@ namespace CookingSkill.Core
         /// <param name="recipe">The crafting recipe.</param>
         /// <param name="item">The crafted item from the recipe. Nothing is changed if the recipe isn't cooking.</param>
         /// <returns>Returns the held item.</returns>
-        Item PreCook(CraftingRecipe recipe, Item item);
+        Item PreCook(CraftingRecipe recipe, Item item, Dictionary<Item, int> consumed_items, Farmer who);
 
         /// <summary>
         /// Grants the player EXP and increases the held Item by the value of the crafting recipe.
@@ -32,9 +32,9 @@ namespace CookingSkill.Core
 
     public class CookingAPI : ICookingApi
     {
-        public Item PreCook(CraftingRecipe recipe, Item item)
+        public Item PreCook(CraftingRecipe recipe, Item item, Dictionary<Item, int> consumed_items, Farmer who)
         {
-            return CookingSkill.Core.Events.PreCook(recipe, item);
+            return CookingSkill.Core.Events.PreCook(recipe, item, consumed_items, who);
         }
 
         public Item PostCook(CraftingRecipe recipe, Item heldItem, Farmer who)

--- a/CookingSkillRedux/Core/HarmonyPatches.cs
+++ b/CookingSkillRedux/Core/HarmonyPatches.cs
@@ -13,12 +13,19 @@ using StardewValley;
 using StardewValley.BellsAndWhistles;
 using StardewValley.Enchantments;
 using StardewValley.Extensions;
+using StardewValley.GameData;
+using StardewValley.GameData.Buildings;
 using StardewValley.GameData.Locations;
+using StardewValley.Internal;
 using StardewValley.Inventories;
+using StardewValley.Buildings;
 using StardewValley.Locations;
 using StardewValley.Menus;
+using StardewValley.Objects;
 using StardewValley.Tools;
 using Object = StardewValley.Object;
+using System.Linq;
+using Microsoft.VisualBasic;
 
 namespace CookingSkill.Core
 {
@@ -29,15 +36,23 @@ namespace CookingSkill.Core
         [HarmonyLib.HarmonyPrefix]
         public static bool ClickCraftingRecipe(CraftingPage __instance, ClickableTextureComponent c, bool playSound, ref int ___currentCraftingPage, ref Item ___heldItem, ref bool ___cooking)
         {
+            //do not change anything not cooking related - pointlessly dangerous
+            if(!___cooking)
+            {
+                return true;
+            }
+            ModEntry.Instance.Monitor.Log("YACS Starting click crafting recipe prefix - should not happen if bettercrafting is instaleld", LogLevel.Trace);
             CraftingRecipe craftingRecipe = __instance.pagesOfCraftingRecipes[__instance.currentCraftingPage][c];
             Item item = craftingRecipe.createItem();
             var player = Game1.getFarmer(Game1.player.UniqueMultiplayerID);
             List<KeyValuePair<string, int>> list = null;
             if (___cooking && item.Quality == 0)
             {
-                //don't allow the player to force a certain quality dish
+                //don't allow the player to force a certain quality dish -
+                //if inventory is full do not allow the craft - display full inventory toaster
                 if (player.isInventoryFull() && ___heldItem != null)
                 {
+                    Game1.showRedMessage(Game1.content.LoadString("Strings\\StringsFromCSFiles:Crop.cs.588"));
                     return false;
                 }
                 list = new List<KeyValuePair<string, int>>();
@@ -55,8 +70,9 @@ namespace CookingSkill.Core
                 /// /////////////////////////////
                 /// Custom Code
                 /// for Cooking
-                var consumed_items = CookingSkill.Core.Events.FigureOutItems(craftingRecipe, __instance._materialContainers);
-                CookingSkill.Core.Events.PreCook(craftingRecipe, item, consumed_items, player);
+                var consumed_items = FigureOutItems(craftingRecipe, __instance._materialContainers);
+                CookingSkill.Core.Events.PreCook(craftingRecipe, item);
+                CookingSkill.Core.Events.PostCook(craftingRecipe, item, consumed_items, player);
                 ////////////////////////////////////
             }
 
@@ -116,12 +132,6 @@ namespace CookingSkill.Core
                 player.cookedRecipe(item.ItemId);
                 Game1.stats.checkForCookingAchievements();
 
-                /// /////////////////////////////
-                /// Custom Code
-                /// for Cooking
-                CookingSkill.Core.Events.PostCook(craftingRecipe, item, player);
-                ////////////////////////////////////
-
             }
             else
             {
@@ -151,6 +161,68 @@ namespace CookingSkill.Core
 
             return list;
         }
+
+        public static Dictionary<Item, int> FigureOutItems(CraftingRecipe recipe, List<IInventory> additionalInventories)
+        {
+            Dictionary<Item, int> items = new Dictionary<Item, int>();
+            foreach (KeyValuePair<string, int> ingredient in recipe.recipeList)
+            {
+                string key = ingredient.Key;
+                int num = ingredient.Value;
+                bool flag = false;
+                for (int num2 = Game1.player.Items.Count - 1; num2 >= 0; num2--)
+                {
+                    if (CraftingRecipe.ItemMatchesForCrafting(Game1.player.Items[num2], key))
+                    {
+                        int amount = num;
+                        num -= Game1.player.Items[num2].Stack;
+                        items.Add(Game1.player.Items[num2], Math.Min(Game1.player.Items[num2].Stack, amount));
+                        if (num <= 0)
+                        {
+                            flag = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (additionalInventories == null || flag)
+                {
+                    continue;
+                }
+
+                for (int i = 0; i < additionalInventories.Count; i++)
+                {
+                    IInventory inventory = additionalInventories[i];
+                    if (inventory == null)
+                    {
+                        continue;
+                    }
+                    for (int num3 = inventory.Count - 1; num3 >= 0; num3--)
+                    {
+                        if (CraftingRecipe.ItemMatchesForCrafting(inventory[num3], key))
+                        {
+                            int num4 = Math.Min(num, inventory[num3].Stack);
+                            num -= num4;
+                            items.Add(inventory[num3], num4);
+
+                            if (num <= 0)
+                            {
+                                break;
+                            }
+                        }
+                    }
+
+
+                    if (num <= 0)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return items;
+        }
+
     }
 
 
@@ -224,4 +296,174 @@ namespace CookingSkill.Core
             return true;
         }
     }
+
+
+    [HarmonyPatch(typeof(StardewValley.Buildings.Building), "CheckItemConversionRule")]
+    class MillItemConversion_patch
+    {
+        [HarmonyLib.HarmonyPrefix]
+        private static bool Prefix(
+        StardewValley.Buildings.Building __instance, BuildingItemConversion conversion, ItemQueryContext itemQueryContext)
+        {
+            if(__instance.buildingType.Value != "Mill") {
+                return true;
+            }
+            ModEntry.Instance.Monitor.Log("Starting to run the logic for Mills", LogLevel.Trace);
+            int[] convertAmount;
+            int[] currentCount = { 0, 0, 0, 0, 0 };
+            List<int[]> consumeCount = new List<int[]>();
+            Chest sourceChest = __instance.GetBuildingChest(conversion.SourceChest);
+            Chest destinationChest = __instance.GetBuildingChest(conversion.DestinationChest);
+            if (sourceChest == null)
+            {
+                return false;
+            }
+            foreach (Item item in sourceChest.Items)
+            {
+                if (item == null)
+                {
+                    continue;
+                }
+                bool fail = false;
+                foreach (string requiredTag in conversion.RequiredTags)
+                {
+                    if (!item.HasContextTag(requiredTag))
+                    {
+                        fail = true;
+                        break;
+                    }
+                }
+                if (fail)
+                {
+                    continue;
+                }
+                currentCount[item.Quality] += item.Stack;
+            }
+            convertAmount = GetConversionsNum(currentCount, consumeCount,conversion.RequiredCount, conversion.MaxDailyConversions);
+            if (convertAmount.Sum() == 0)
+            {
+                return false;
+            }
+            int totalConversions = 0; 
+            int[] requiredAmount = { 0, 0, 0, 0, 0 };
+            ModEntry.Instance.Monitor.Log($"Will try to produce [{string.Join(", ", convertAmount)}]", LogLevel.Trace);
+            for (int j = 0; j < convertAmount.Sum(); j++)
+            {
+                bool conversionCreatedItem = false;
+                for (int i = 0; i < conversion.ProducedItems.Count; i++)
+                {
+                    GenericSpawnItemDataWithCondition producedItem = conversion.ProducedItems[i];
+                    if (GameStateQuery.CheckConditions(producedItem.Condition, __instance.GetParentLocation()))
+                    {
+                        Item item = ItemQueryResolver.TryResolveRandomItem(producedItem, itemQueryContext);
+
+                        //round off quality
+                        double average_quality = (double)(consumeCount[j][1] + consumeCount[j][2]*2 + consumeCount[j][4] * 3) / consumeCount[j].Sum();
+                        double chance = average_quality - (int)average_quality;
+                        int quality = (int)average_quality;
+                        if(Game1.random.NextDouble() < chance)
+                        {quality++;}
+
+                        //add +- 1 with random chance
+                        int r = Game1.random.Next(15);
+                        if(r == 0)
+                        {quality++;}
+                        else if (r < 5)
+                        {quality--;}
+                        if (quality >= 3)
+                        {quality = 4;}
+                        item.Quality = quality;
+                        //currently, quality is the quality of the worst ingredient. Can be possibly changed to some sort of mean.
+                        int producedCount = item.Stack;
+                        Item item2 = destinationChest.addItem(item);
+                        if (item2 == null || item2.Stack != producedCount)
+                        {
+                            conversionCreatedItem = true;
+                        }
+                    }
+                }
+                if (conversionCreatedItem)
+                {
+                    totalConversions++;
+                    for(int k = 0; k < 5; k++)
+                    {
+                        requiredAmount[k] += consumeCount[j][k];
+                    }
+                }
+            }
+            if (totalConversions <= 0)
+            {
+                return false;
+            }
+            ModEntry.Instance.Monitor.Log($"Need to delete [{string.Join(", ", requiredAmount)}]", LogLevel.Trace);
+
+            for (int i = 0; i < sourceChest.Items.Count; i++)
+            {
+                Item item = sourceChest.Items[i];
+                if (item == null)
+                {
+                    continue;
+                }
+                bool fail = false;
+                foreach (string requiredTag in conversion.RequiredTags)
+                {
+                    if (!item.HasContextTag(requiredTag))
+                    {
+                        fail = true;
+                        break;
+                    }
+                }
+                if (!fail)
+                {
+                    int consumedAmount = Math.Min(requiredAmount[item.Quality], item.Stack);
+                    sourceChest.Items[i] = item.ConsumeStack(consumedAmount);
+                    requiredAmount[item.Quality] -= consumedAmount;
+                    if (requiredAmount.Sum() <= 0)
+                    {
+                        break;
+                    }
+                }
+            }
+            return false;
+        }
+
+        public static int[] GetConversionsNum(int[] currentCount, List<int[]> consumeCounts, int requiredCount, int maxConversions)
+        {
+            int currCount = 0;
+            int[] conversions = { 0, 0, 0, 0, 0 };
+            int[] tempCount;
+            int[] counts = currentCount;
+            //this is stupid but it should work
+            if(maxConversions == -1)
+            {
+                maxConversions = int.MaxValue;
+            }
+            for (int i = conversions.Length - 1; i >= 0 && maxConversions > 0; i--)
+            {
+                //all conversions done one by one as items are created one by one in the end
+                //"recipes" for conversions stored in the list.
+                while (counts[i] + currCount >= requiredCount && maxConversions > 0)
+                {
+                    conversions[i]++;
+                    tempCount = Enumerable.Repeat(0, 5).ToArray();
+                    counts[i] -= requiredCount - currCount;
+                    tempCount[i] = requiredCount - currCount;
+                    int j = i + 1;
+                    int prevCount = currCount;
+                    while (currCount > 0)
+                    {
+                        currCount -= Math.Min(counts[j], currCount);
+                        tempCount[j] = Math.Min(counts[j], prevCount);
+                        counts[j] -= Math.Min(counts[j], prevCount);
+                        j++;
+                    }
+                    maxConversions--;
+                    consumeCounts.Add(tempCount);
+                }
+                currCount += counts[i];
+            }
+            return conversions;
+        }
+    }
+
 }

--- a/CookingSkillRedux/Core/Utilities.cs
+++ b/CookingSkillRedux/Core/Utilities.cs
@@ -8,6 +8,7 @@ namespace CookingSkill
 {
     internal class Utilities
     {
+        public static Item BetterCraftingTempItem;
 
         public static void AddEXP(StardewValley.Farmer who, int amount)
         {


### PR DESCRIPTION
Quality was added to dishes as part of the skill. Quality comprises of 4 factors. The first is the quality of the ingredients, the second is the experience making the dish, the third is the level of the cooking skill, and last is randomness. Collecting information about ingredients was added to Events. 

To allow for quality to be random and eliminate things like forcing quality by having the held item be an iridium quality dish, changes were made to the crafting system to make new items be added to the inventory instead of to the held item if the held item is already full/cannot fit them. Additionally, you can no longer craft **cooking** dishes with a full inventory and a full held item to prevent forcing of high quality dishes. 

Integration with better crafting is impossible with this new system without cooperation with the better crafting mod author.