### PR TITLE
Fixed bug where I accidently made negative quality possible in the mill.

### DIFF
--- a/CookingSkillRedux/Core/HarmonyPatches.cs
+++ b/CookingSkillRedux/Core/HarmonyPatches.cs
@@ -317,6 +317,8 @@ namespace CookingSkill.Core
                         {quality--;}
                         if (quality >= 3)
                         {quality = 4;}
+                        if (quality < 0)
+                        { quality = 0; }
                         item.Quality = quality;
                         //currently, quality is the quality of the worst ingredient. Can be possibly changed to some sort of mean.
                         int producedCount = item.Stack;


### PR DESCRIPTION
Sorry about that, I thought I accounted for it and now with more testing I realized I didn't. This is a 2 line fixed so you can fix it locally and reject the PR if you already made changes to the file locally.